### PR TITLE
Fixed a typo in py_ext/tlshmodule.cpp

### DIFF
--- a/py_ext/tlshmodule.cpp
+++ b/py_ext/tlshmodule.cpp
@@ -20,7 +20,7 @@ static char tlsh_diffxlen_doc[] =
 static PyObject* hash_py(PyObject* self, PyObject* args) {
   unsigned char* pBuffer;
   int len;
-  if (!PyArg_ParseTuple(args, "t#", &pBuffer, &len)) {
+  if (!PyArg_ParseTuple(args, "s#", &pBuffer, &len)) {
     return NULL;
   }
   


### PR DESCRIPTION
A typo was preventing hash_py function from accepting strings as its input. I changed the input format. It now works under Python 3.4.2 and Python 2.7.8. However, there might be a need for someone to test under 2.7.8 more extensively as I primarily work with 3.x .

Thank you.