### PR TITLE
Remove a Bash-ism from make.sh

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ $# -eq 1 -a "$1" == "debug" ]; then
+if [ $# -eq 1 -a "$1" = "debug" ]; then
   mkdir -p build/debug
   cd build/debug
   cmake -DCMAKE_BUILD_TYPE=Debug ../..


### PR DESCRIPTION
In the shebang we just use "sh", so we must not use any Bash specific
constructs.