### PR TITLE
using PYTHONPATH to run tests against local library

### DIFF
--- a/Testing/python_test.sh
+++ b/Testing/python_test.sh
@@ -5,15 +5,29 @@ echoerr() { echo "$@" 1>&2; }
 BASEDIR=$(dirname $0)
 pushd $BASEDIR > /dev/null
 TMP="tmp"
+PYTHON=$1
+
+if [ -z "${PYTHON}" ]
+then
+    PYTHON="python"
+fi
 
 if test ! -d tmp
 then
     mkdir tmp
 fi
 
+if [ -z "${CARCH}" ]
+then
+    CARCH=$(uname -m)
+fi
+
+PYTHONVERSION="$(${PYTHON} -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')"
+PYTHONPATH="../py_ext/build/lib.linux-${CARCH}-${PYTHONVERSION}:${PYTHONPATH}"
+
 echo ""
-echo "Running python tests"
-python ../py_ext/test.py ../Testing/example_data/2005NISSE.txt ../Testing/example_data/1english-only.txt > $TMP/python_test.out
+echo "Running ${PYTHON} tests for ${CARCH}"
+PYTHONPATH=${PYTHONPATH} ${PYTHON} ../py_ext/test.py ../Testing/example_data/2005NISSE.txt ../Testing/example_data/1english-only.txt > $TMP/python_test.out
 diff --ignore-all-space $TMP/python_test.out exp/python_test_EXP > /dev/null 2>/dev/null
 if [ $? -ne 0 ]; then
 	echoerr "error: diff $TMP/python_test.out exp/python_test_EXP"


### PR DESCRIPTION
this resolves the issue that the library needs to be installed
into the system before the tests can work correctly.

Also it is possible to pass the python executable as the first
parameter, allowing to test both, python2 and python3

external CARCH environment var allowes to either override the arch
(on cross-platform packaging of i686 packages build on x64) or get
the default architecture via uname -m