### PR TITLE
convert arg to bytes object before passing to PyBytes_AsStringAndSize

### DIFF
--- a/py_ext/tlshmodule.cpp
+++ b/py_ext/tlshmodule.cpp
@@ -178,6 +178,18 @@ Tlsh_fromTlshStr(tlsh_TlshObject *self, PyObject *args)
         return PyErr_Format(PyExc_TypeError, "function takes exactly 1 argument (%lu given)", PyTuple_Size(args));
 
     arg = PyTuple_GetItem(args, 0);
+#if PY_MAJOR_VERSION >= 3
+    if (!PyUnicode_Check(arg) || (arg = PyUnicode_AsASCIIString(arg)) == NULL) {
+      PyErr_SetString(PyExc_ValueError, "argument is not a TLSH hex string");
+      return NULL;
+    }
+#else
+    if (!PyString_Check(arg)) {
+      PyErr_SetString(PyExc_ValueError, "argument is not a TLSH hex string");
+      return NULL;
+    }
+#endif
+
     if (PyBytes_AsStringAndSize(arg, &str, &len) == -1) {
         PyErr_SetString(PyExc_ValueError, "argument is not a TLSH hex string");
         return NULL;


### PR DESCRIPTION
this fixes python3 and ensures for both, python2 and python3 that
the passed argument is a string.

this fixes #14 