### PR TITLE
Fixed memory allocation bug in tlsh_unittest and add NULL check (Large Dir Crash)

### DIFF
--- a/test/tlsh_unittest.cpp
+++ b/test/tlsh_unittest.cpp
@@ -340,7 +340,12 @@ int max_files;
 		return;
 
 	struct FileName *fnames;
-	fnames = (struct FileName *) calloc ( max_files+1, sizeof(struct FileName) * (max_files+1) );
+	fnames = (struct FileName *) calloc ( max_files+1, sizeof(struct FileName));
+	if (fnames == NULL) {
+		fprintf(stderr, "error: unable to allocate memory for %d files\n", max_files);
+		exit(1);
+	}
+	
 	int err;
 	int n_file = 0;
 	if (dirname) {


### PR DESCRIPTION
trendLSH_ut allocates max_files*sizeof(struct FileName) times max_files memory to hold the filenames, we only need max_files*sizeof(struct FileName)