### PR TITLE
Add a mention of Ruby port of TLSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ hash values to determine similarity.  Run it with no parameters for detailed usa
 - A Java port is available [here](https://github.com/triplecheck/TLSH).
 - A JavaScript port available in the `js_ext` directory.
 - A Golang port is available [here](https://github.com/glaslos/tlsh).
+- A Ruby port is available [here](https://github.com/adamliesko/tlsh).
 
 # Downloading TLSH
 


### PR DESCRIPTION
Hey,

I implemented TLSH port in Ruby based on trendmicro's original and existing Go implementation. Hosted at https://github.com/adamliesko/tlsh, open sourced as a Ruby gem.

Is MIT license ok, or given that the original tlsh repo is published under Apache 2.0, I have to follow it? I have included the NOTICE.txt file.

Thank you for your work.