### PR TITLE
Publish compiled JAR file on bintray.com

### DIFF
--- a/java/.classpath
+++ b/java/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry kind="src" path="src/main/resources"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/java/.project
+++ b/java/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>trendmicro-tlsh</name>
+	<name>tlsh</name>
 	<comment>Project tlsh created by Buildship.</comment>
 	<projects>
 	</projects>

--- a/java/.settings/org.eclipse.jdt.core.prefs
+++ b/java/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.source=1.7

--- a/java/README.md
+++ b/java/README.md
@@ -2,7 +2,29 @@
 
 This folder contains a Java port of the Trend Micro Locality Sensitive Hash algorithm
 
-Example usage:
+## Use with gradle
+
+Pre-built versions of TLSH are hosted on bintray and can be used in gradle build scripts as follows:
+
+```
+repositories {
+    jcenter()
+
+     maven {
+         url  "https://dl.bintray.com/mrpolyonymous/tlsh"
+     }
+}
+
+dependencies {
+	compile 'com.trendmicro:tlsh:3.7.1'
+	
+    // ... other dependencies
+}
+```
+
+**Note**: The process of getting the TLSH library in the main JCenter repository is under way.
+
+## Example
 ```java
 import com.trendmicro.tlsh.Tlsh;
 import com.trendmicro.tlsh.TlshCreator;

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -6,7 +6,14 @@
  * user guide available at https://docs.gradle.org/3.5/userguide/java_library_plugin.html
  */
 
-// Apply the java-library plugin to add support for Java Library
+plugins {
+    id "com.jfrog.bintray" version "1.7.3"
+}
+
+// Apply the required plugins
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
+apply plugin: 'java'
 apply plugin: 'java-library'
 
 // In this section you declare where to find the dependencies of your project
@@ -21,11 +28,65 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 }
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.7
 version = '3.7.1'
+def globalVersion = version
+group = 'com.trendmicro'
+
 jar {
     manifest {
         attributes 'Implementation-Title': 'TLSH - Trend Micro Locality Sensitive Hash',
-                   'Implementation-Version': version
+                   'Implementation-Version': globalVersion
     }
 }
+
+// To upload to bintray, run
+//   ./gradlew bintrayUpload
+bintray {
+	user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+	key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
+
+    pkg {
+        repo = 'tlsh'
+        name = 'TLSH'
+
+        version {
+            name = globalVersion
+            desc = 'TLSH - Trend Micro Locality Sensitive Hash'
+            released  = new Date()
+        }
+
+    }
+
+    publications = ['tlsh'] 
+}
+
+// Create the publication with the pom configuration:
+publishing {
+    publications {
+        tlsh(MavenPublication) {
+            from components.java
+            artifact javadocJar
+            artifact sourcesJar
+            groupId 'com.trendmicro'
+            artifactId 'tlsh'
+            version globalVersion
+        }
+    }
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+

--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -15,4 +15,4 @@ include 'api'
 include 'services:webservice'
 */
 
-rootProject.name = 'trendmicro-tlsh'
+rootProject.name = 'tlsh'

--- a/java/src/test/java/com/trendmicro/tlsh/ExampleDataUtilities.java
+++ b/java/src/test/java/com/trendmicro/tlsh/ExampleDataUtilities.java
@@ -198,13 +198,19 @@ public class ExampleDataUtilities {
 	 * Not safe for large files.
 	 */
 	public static byte[] getFileBytes(File exampleFile) {
-		return fileCache.computeIfAbsent(exampleFile, (File f) -> {
+		// Would be nice to use Map.computeIfAbsent but that requires 1.8-level
+		// source compatibility
+		byte[] bytes = fileCache.get(exampleFile);
+		if (bytes == null) {
 			try {
-				return Files.readAllBytes(f.toPath());
+				bytes = Files.readAllBytes(exampleFile.toPath());
 			} catch (IOException e) {
 				throw new RuntimeException("Cannot read file " + exampleFile, e);
 			}
-		});
+			fileCache.put(exampleFile, bytes);
+			
+		}
+		return bytes;
 	}
 
 	public static void clearFileCache() {


### PR DESCRIPTION
JAR files are much more likely to be used if they're available through common distribution platforms so I've set up an account on bintray.com and modified the build script to make upload painless.

Major changes:
* switch to source level 1.7 from 1.8 to make the compiled code usable by those stuck on older versions of Java
* modify build.gradle to use the bintray plugin so that uploads can be automated
* Update README to point to current bintray distribution of the library