### PR TITLE
Fixed double-free when destroying a copied Tlsh instance

### DIFF
--- a/include/tlsh_impl.h
+++ b/include/tlsh_impl.h
@@ -112,6 +112,10 @@ class TlshImpl
 public:
     TlshImpl();
     ~TlshImpl();
+
+public:
+    TlshImpl& operator=(const TlshImpl& other);
+
 public:
     void       update(const unsigned char* data, unsigned int len);
     void  fast_update(const unsigned char* data, unsigned int len);

--- a/src/tlsh_impl.cpp
+++ b/src/tlsh_impl.cpp
@@ -89,6 +89,34 @@ TlshImpl::~TlshImpl()
     delete [] this->lsh_code;
 }
 
+TlshImpl& TlshImpl::operator=(const TlshImpl& other)
+{
+    if (this == &other)
+        return *this;
+
+    if (other.a_bucket != NULL) {
+        if (this->a_bucket == NULL) {
+            this->a_bucket = new unsigned int[BUCKETS];
+        }
+        memcpy(this->a_bucket, other.a_bucket, BUCKETS*sizeof(*this->a_bucket));
+    } else {
+        delete [] this->a_bucket; this->a_bucket = NULL;
+    }
+    memcpy(this->slide_window, other.slide_window, SLIDING_WND_SIZE);
+    this->data_len = other.data_len;
+    this->lsh_bin = other.lsh_bin;
+    if (other.lsh_code != NULL) {
+        if (this->lsh_code == NULL) {
+            this->lsh_code = new char[TLSH_STRING_LEN_REQ+1];
+        }
+        memcpy(this->lsh_code, other.lsh_code, TLSH_STRING_LEN_REQ+1);
+    } else {
+        delete [] this->lsh_code; this->lsh_code = NULL;
+    }
+    this->lsh_code_valid = other.lsh_code_valid;
+    return *this;
+}
+
 void TlshImpl::reset()
 {
     delete [] this->a_bucket; this->a_bucket = NULL;


### PR DESCRIPTION
# Summary
Sometimes, double-free occurs when destroying a copied Tlsh instance.
A cause of the issue is when the Tlsh instance is assigned to another instance, default TlshImpl's operator=() method copies dynamically allocated memory areas by shallow copy. Therefore, when both copy source and copy destination are freed, same areas are freed twice.
This change solves the issue by copying the areas by deep copy, and makes Tlsh instances copyable.

# Changes
Implement operator=(const TlshImpl&) method in the Tlsh class. The method allocates/frees dynamically allocated memory areas as necessary, and then copies data from source instance by deep copy.

# Remark
TlshImpl's copy constructor has the same issue. However, the constructor is never used, so there is unnecessary to implement it.

# Reproduction code of the issue
```
Tlsh* tlsh[5];

tlsh[0] = new Tlsh();
tlsh[1] = new Tlsh(*tlsh[0]);
for (unsigned char i = 0; i < 255; ++i) tlsh[0]->update(&i, 1);
tlsh[2] = new Tlsh(*tlsh[0]);
tlsh[0]->final();
tlsh[3] = new Tlsh(*tlsh[0]);
tlsh[0]->getHash();
tlsh[4] = new Tlsh(*tlsh[0]);

delete tlsh[0];	// success.
delete tlsh[1];	// success.
delete tlsh[2];	// failed because tlsh1->a_bucket is double-freed.
delete tlsh[3];	// success.
delete tlsh[4];	// failed because tlsh1->lsh_code is double-freed.
```