### PR TITLE
Fix tmpArray is undefined

### DIFF
--- a/js_ext/tlsh.js
+++ b/js_ext/tlsh.js
@@ -535,7 +535,7 @@ Tlsh.prototype.hash = function ()
 
     this.lsh_code = to_hex(tmp.checksum, TLSH_CHECKSUM_LEN);
 
-    tmpArray = new Uint8Array(1);
+    let tmpArray = new Uint8Array(1);
     tmpArray[0] = tmp.Lvalue;
     this.lsh_code = this.lsh_code.concat(to_hex(tmpArray, 1));
 


### PR DESCRIPTION
When running this in the latest chrome I got an undefined error for tmpArray. Defining it with let resolves the error.