### PR TITLE
Java fix for issue #99

### DIFF
--- a/java/.classpath
+++ b/java/.classpath
@@ -1,9 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="src" path="src/test/java"/>
-	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="src" output="bin/main" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="bin/main" path="src/main/resources">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="bin/test" path="src/test/java">
+		<attributes>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/java/.project
+++ b/java/.project
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
 	<name>tlsh</name>
-	<comment>Project tlsh created by Buildship.</comment>
+	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
@@ -17,7 +17,7 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/java/.settings/org.eclipse.buildship.core.prefs
+++ b/java/.settings/org.eclipse.buildship.core.prefs
@@ -1,3 +1,2 @@
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
 connection.project.dir=
 eclipse.preferences.version=1

--- a/java/.settings/org.eclipse.jdt.core.prefs
+++ b/java/.settings/org.eclipse.jdt.core.prefs
@@ -1,4 +1,13 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+#
+#Tue Apr 20 07:46:11 EDT 2021
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error

--- a/java/README.md
+++ b/java/README.md
@@ -6,44 +6,16 @@ This port has no additional JAR dependencies and only requires the JRE.
 
 ## Use with gradle
 
-Pre-built versions of TLSH are hosted on bintray and can be used in gradle build scripts as follows:
+Pre-built TLSH libraries will be available on Maven Central soon but for now they
+must be built from source.
 
-```
-repositories {
-  jcenter()
-  // ... other repositories
-}
-
-dependencies {
-  compile 'com.trendmicro:tlsh:3.7.1'
-
-  // ... other dependencies
-}
+```bash
+git clone https://github.com/trendmicro/tlsh.git
+cd tlsh/java
+./gradlew clean build
 ```
 
-## Use with Maven
-
-Pre-built versions of TLSH can be used in a Maven pom.xml file as follows:
-
-```xml
-<repositories>
-  <repository>
-    <id>jcenter</id>
-    <url>https://jcenter.bintray.com/</url>
-  </repository>
-  <!-- ... other repositories -->
-</repositories>
-
-<dependencies>
-  <dependency>
-    <groupId>com.trendmicro</groupId>
-    <artifactId>tlsh</artifactId>
-    <version>3.7.1</version>
-    <type>pom</type>
-  </dependency>
-  <!-- ... other dependencies -->
-</dependencies>
-```
+This will produce JAR files in `build/libs` that can be included in other projects.
 
 ## Example
 ```java

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -6,21 +6,16 @@
  * user guide available at https://docs.gradle.org/3.5/userguide/java_library_plugin.html
  */
 
-plugins {
-    id "com.jfrog.bintray" version "1.7.3"
-}
-
 // Apply the required plugins
-apply plugin: 'maven'
-apply plugin: 'maven-publish'
-apply plugin: 'java'
-apply plugin: 'java-library'
+plugins {
+    id 'java'
+    id 'java-library'
+    id 'eclipse'
+}
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use jcenter for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
@@ -29,7 +24,7 @@ dependencies {
 }
 
 sourceCompatibility = 1.7
-version = '3.7.1'
+version = '4.5.0'
 def globalVersion = version
 group = 'com.trendmicro'
 
@@ -37,41 +32,6 @@ jar {
     manifest {
         attributes 'Implementation-Title': 'TLSH - Trend Micro Locality Sensitive Hash',
                    'Implementation-Version': globalVersion
-    }
-}
-
-// To upload to bintray, run
-//   ./gradlew bintrayUpload
-bintray {
-	user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
-	key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
-
-    pkg {
-        repo = 'tlsh'
-        name = 'TLSH'
-
-        version {
-            name = globalVersion
-            desc = 'TLSH - Trend Micro Locality Sensitive Hash'
-            released  = new Date()
-        }
-
-    }
-
-    publications = ['tlsh'] 
-}
-
-// Create the publication with the pom configuration:
-publishing {
-    publications {
-        tlsh(MavenPublication) {
-            from components.java
-            artifact javadocJar
-            artifact sourcesJar
-            groupId 'com.trendmicro'
-            artifactId 'tlsh'
-            version globalVersion
-        }
     }
 }
 

--- a/java/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip

--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -8,11 +8,4 @@
  * in the user guide at https://docs.gradle.org/3.5/userguide/multi_project_builds.html
  */
 
-/*
-// To declare projects as part of a multi-project build use the 'include' method
-include 'shared'
-include 'api'
-include 'services:webservice'
-*/
-
 rootProject.name = 'tlsh'

--- a/java/src/main/java/com/trendmicro/tlsh/TlshUtil.java
+++ b/java/src/main/java/com/trendmicro/tlsh/TlshUtil.java
@@ -98,15 +98,16 @@ final class TlshUtil {
 		return h;
 	}
 
-	/** Natural logarithm of 1.5 */
-	private static final double LOG_1_5 = 0.4054651;
-	/** Natural logarithm of 1.3 */
-	private static final double LOG_1_3 = 0.26236426;
-	/** Natural logarithm of 1.1 */
-	private static final double LOG_1_1 = 0.095310180;
+//	/** Natural logarithm of 1.5 */
+//	private static final double LOG_1_5 = 0.4054651;
+//	/** Natural logarithm of 1.3 */
+//	private static final double LOG_1_3 = 0.26236426;
+//	/** Natural logarithm of 1.1 */
+//	private static final double LOG_1_1 = 0.095310180;
 
-	/** Compute length portion of TLSH */
-	static int l_capturing(int len) {
+	/* Compute length portion of TLSH */
+	/*
+	static int l_capturing(long len) {
 		int i;
 		if (len <= 656) {
 			i = (int) Math.floor(Math.log(len) / LOG_1_5);
@@ -117,6 +118,209 @@ final class TlshUtil {
 		}
 
 		return i & 0xFF;
+	}
+	*/
+
+	private static final long topval[] = {
+		1,
+		2,
+		3,
+		5,
+		7,
+		11,
+		17,
+		25,
+		38,
+		57,
+		86,
+		129,
+		194,
+		291,
+		437,
+		656,
+		854,
+		1110,
+		1443,
+		1876,
+		2439,
+		3171,
+		3475,
+		3823,
+		4205,
+		4626,
+		5088,
+		5597,
+		6157,
+		6772,
+		7450,
+		8195,
+		9014,
+		9916,
+		10907,
+		11998,
+		13198,
+		14518,
+		15970,
+		17567,
+		19323,
+		21256,
+		23382,
+		25720,
+		28292,
+		31121,
+		34233,
+		37656,
+		41422,
+		45564,
+		50121,
+		55133,
+		60646,
+		66711,
+		73382,
+		80721,
+		88793,
+		97672,
+		107439,
+		118183,
+		130002,
+		143002,
+		157302,
+		173032,
+		190335,
+		209369,
+		230306,
+		253337,
+		278670,
+		306538,
+		337191,
+		370911,
+		408002,
+		448802,
+		493682,
+		543050,
+		597356,
+		657091,
+		722800,
+		795081,
+		874589,
+		962048,
+		1058252,
+		1164078,
+		1280486,
+		1408534,
+		1549388,
+		1704327,
+		1874759,
+		2062236,
+		2268459,
+		2495305,
+		2744836,
+		3019320,
+		3321252,
+		3653374,
+		4018711,
+		4420582,
+		4862641,
+		5348905,
+		5883796,
+		6472176,
+		7119394,
+		7831333,
+		8614467,
+		9475909,
+		10423501,
+		11465851,
+		12612437,
+		13873681,
+		15261050,
+		16787154,
+		18465870,
+		20312458,
+		22343706,
+		24578077,
+		27035886,
+		29739474,
+		32713425,
+		35984770,
+		39583245,
+		43541573,
+		47895730,
+		52685306,
+		57953837,
+		63749221,
+		70124148,
+		77136564,
+		84850228,
+		93335252,
+		102668779,
+		112935659,
+		124229227,
+		136652151,
+		150317384,
+		165349128,
+		181884040,
+		200072456,
+		220079703,
+		242087671,
+		266296456,
+		292926096,
+		322218735,
+		354440623,
+		389884688,
+		428873168,
+		471760495,
+		518936559,
+		570830240,
+		627913311,
+		690704607,
+		759775136,
+		835752671,
+		919327967,
+		1011260767,
+		1112386880,
+		1223623232,
+		1345985727,
+		1480584256,
+		1628642751,
+		1791507135,
+		1970657856,
+		2167723648L,
+		2384496256L,
+		2622945920L,
+		2885240448L,
+		3173764736L,
+		3491141248L,
+		3840255616L,
+		4224281216L
+	};
+	
+	/**
+	 * The maximum amount of data allowed in a TLSH computation.
+	 * Slightly less than 4GiB.
+	 */
+	static final long MAX_DATA_LENGTH = topval[topval.length-1];
+	
+	/** Compute length portion of TLSH */
+	static int l_capturing(long len) {
+		int bottom = 0;
+		int top = topval.length;
+		int idx = top >> 1;
+
+		while (idx < topval.length) {
+			if (idx == 0) {
+				return idx;
+			}
+			if ((len <= topval[idx]) && (len > topval[idx-1])) {
+				return idx;
+			}
+			if (len < topval[idx]) {
+				top = idx - 1;
+			} else {
+				bottom = idx + 1;
+			}
+			idx = (bottom + top) >> 1;
+		}
+		throw new IllegalArgumentException("Can only compute length portion of TLSH for data lengths up to " + MAX_DATA_LENGTH + " bytes");
 	}
 
 	static int mod_diff(int x, int y, int R) {

--- a/java/src/main/java/com/trendmicro/tlsh/VersionOption.java
+++ b/java/src/main/java/com/trendmicro/tlsh/VersionOption.java
@@ -1,0 +1,76 @@
+/*
+ * TLSH is provided for use under two licenses: Apache OR BSD.
+ * Users may opt to use either license depending on the license
+ * restictions of the systems with which they plan to integrate
+ * the TLSH code.
+ */
+
+/* ==============
+ * Apache License
+ * ==============
+ * Copyright 2021 Trend Micro Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ===========
+ * BSD License
+ * ===========
+ * Copyright (c) 2021, Trend Micro Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.trendmicro.tlsh;
+
+/** Enum for version information to include in an encoded TLSH string */
+public enum VersionOption {
+	/** The original version of TLSH that does not include any version data */
+	ORIGINAL(""),
+	/** version information included by TLSH 4.x */
+	VERSION_4("T1");
+	
+	private final String versionString;
+	private VersionOption(String versionString) {
+		this.versionString = versionString;
+	}
+	String getVersionString() {
+		return versionString;
+	}
+	
+	
+}

--- a/java/src/main/resources/README.md
+++ b/java/src/main/resources/README.md
@@ -1,0 +1,3 @@
+# Resources
+
+This file exists so the src/main/resources directory will exist and keep Eclipse happy

--- a/java/src/test/java/com/trendmicro/tlsh/TlshTest.java
+++ b/java/src/test/java/com/trendmicro/tlsh/TlshTest.java
@@ -56,7 +56,13 @@
  */
 package com.trendmicro.tlsh;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -64,6 +70,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -84,82 +91,87 @@ public class TlshTest {
 		ExampleDataUtilities.clearFileCache();
 	}
 	
-    @Test
-    public void test_hash_128_checksum_1() throws IOException {
-    		test_hash(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B);
-    }
+	@Test
+	public void test_hash_128_checksum_1() throws IOException {
+		test_hash(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B, VersionOption.VERSION_4);
+	}
 
-    @Test
-    public void test_hash_128_checksum_3() throws IOException {
-    		test_hash(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_3B);
-    }
+	@Test
+	public void test_hash_128_checksum_3() throws IOException {
+		test_hash(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_3B);
+	}
 
-    @Test
-    public void test_hash_256_checksum_1() throws IOException {
-    		test_hash(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_1B);
-    }
+	@Test
+	public void test_hash_256_checksum_1() throws IOException {
+		test_hash(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_1B);
+	}
 
-    @Test
-    public void test_hash_256_checksum_3() throws IOException {
-    		test_hash(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_3B);
-    }
+	@Test
+	public void test_hash_256_checksum_3() throws IOException {
+		test_hash(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_3B);
+	}
 
-    private void test_hash(BucketOption bucketOption, ChecksumOption checksumOption) throws IOException {
-    		Map<File, String> expectedHashes = ExampleDataUtilities.getExpectedHashes(sourceRoot, bucketOption.getBucketCount(), checksumOption.getChecksumLength());
-    		assertNotNull(expectedHashes);
-    		assertFalse(expectedHashes.isEmpty());
-    		
-    		TlshCreator tlsh = new TlshCreator(bucketOption, checksumOption);
-    		for (Map.Entry<File, String> fileAndHash : expectedHashes.entrySet()) {
-    			byte[] wholeFile = ExampleDataUtilities.getFileBytes(fileAndHash.getKey());
-        		tlsh.update(wholeFile);
-        		assertTrue(tlsh.isValid(false));
-        		String hash = tlsh.getHash(false).toString();
-    			assertEquals("Hashes do not match for file " + fileAndHash.getKey().getAbsolutePath(), fileAndHash.getValue(), hash);
-    			tlsh.reset();
-    			assertFalse(tlsh.isValid(false));
-    		}
-    }
+	private void test_hash(BucketOption bucketOption, ChecksumOption checksumOption) throws IOException {
+		test_hash(bucketOption, checksumOption, VersionOption.ORIGINAL);
+	}
 
-    @Test
-    public void test_diff_128_checksum_1_with_length() throws IOException {
-    		test_diff(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B, true);
-    }
+	private void test_hash(BucketOption bucketOption, ChecksumOption checksumOption, VersionOption versionOption) throws IOException {
+		Map<File, String> expectedHashes = ExampleDataUtilities.getExpectedHashes(sourceRoot, bucketOption.getBucketCount(), checksumOption.getChecksumLength());
+		assertNotNull(expectedHashes);
+		assertFalse(expectedHashes.isEmpty());
+		
+		TlshCreator tlsh = new TlshCreator(bucketOption, checksumOption, versionOption);
+		for (Map.Entry<File, String> fileAndHash : expectedHashes.entrySet()) {
+			byte[] wholeFile = ExampleDataUtilities.getFileBytes(fileAndHash.getKey());
+			boolean smallSource = wholeFile.length < TlshCreator.MIN_DATA_LENGTH;
+			tlsh.update(wholeFile);
+			assertTrue(tlsh.isValid(smallSource));
+			String hash = tlsh.getHash(smallSource).toString();
+			assertEquals("Hashes do not match for file " + fileAndHash.getKey().getAbsolutePath(), fileAndHash.getValue(), hash);
+			tlsh.reset();
+			assertFalse(tlsh.isValid(false));
+		}
+	}
 
-    @Test
-    public void test_diff_128_checksum_1_without_length() throws IOException {
-    		test_diff(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B, false);
-    }
+	@Test
+	public void test_diff_128_checksum_1_with_length() throws IOException {
+		test_diff(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B, true);
+	}
 
-    @Test
-    public void test_diff_128_checksum_3_with_length() throws IOException {
-    		test_diff(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_3B, true);
-    }
+	@Test
+	public void test_diff_128_checksum_1_without_length() throws IOException {
+		test_diff(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B, false);
+	}
 
-    @Test
-    public void test_diff_128_checksum_3_without_length() throws IOException {
-    		test_diff(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_3B, false);
-    }
+	@Test
+	public void test_diff_128_checksum_3_with_length() throws IOException {
+		test_diff(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_3B, true);
+	}
 
-    @Test
-    public void test_diff_256_checksum_1_with_length() throws IOException {
-    		test_diff(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_1B, true);
-    }
+	@Test
+	public void test_diff_128_checksum_3_without_length() throws IOException {
+		test_diff(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_3B, false);
+	}
 
-    @Test
-    public void test_diff_256_checksum_1_without_length() throws IOException {
-    		test_diff(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_1B, false);
-    }
+	@Test
+	public void test_diff_256_checksum_1_with_length() throws IOException {
+		test_diff(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_1B, true);
+	}
 
-    @Test
-    public void test_diff_256_checksum_3_with_length() throws IOException {
-    		test_diff(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_3B, true);
-    }
+	@Test
+	public void test_diff_256_checksum_1_without_length() throws IOException {
+		test_diff(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_1B, false);
+	}
 
-    @Test
-    public void test_diff_256_checksum_3_without_length() throws IOException {
-    		test_diff(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_3B, false);
-    }
+	@Test
+	public void test_diff_256_checksum_3_with_length() throws IOException {
+		test_diff(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_3B, true);
+	}
+
+	@Test
+	public void test_diff_256_checksum_3_without_length() throws IOException {
+		test_diff(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_3B, false);
+	}
 
 	private void test_diff(BucketOption bucketOption, ChecksumOption checksumOption, boolean includeLength) throws FileNotFoundException, IOException
 			{
@@ -168,276 +180,312 @@ public class TlshTest {
 		assertNotNull(expectedDiffs);
 		assertFalse(expectedDiffs.isEmpty());
 
-    		for (ExampleDataUtilities.FilesAndDiff filesAndDiff : expectedDiffs) {
-    			byte[] sourceFile = ExampleDataUtilities.getFileBytes(filesAndDiff.sourceFile);
-    			byte[] targetFile = ExampleDataUtilities.getFileBytes(filesAndDiff.targetFile);
+		for (ExampleDataUtilities.FilesAndDiff filesAndDiff : expectedDiffs) {
+			byte[] sourceFile = ExampleDataUtilities.getFileBytes(filesAndDiff.sourceFile);
+			byte[] targetFile = ExampleDataUtilities.getFileBytes(filesAndDiff.targetFile);
+			boolean smallSource = sourceFile.length < TlshCreator.MIN_DATA_LENGTH;
+			boolean smallTarget = targetFile.length < TlshCreator.MIN_DATA_LENGTH;
 
-        		TlshCreator sourceTlshCreator = new TlshCreator(bucketOption, checksumOption);
-        		sourceTlshCreator.update(sourceFile);
-        		assertTrue(sourceTlshCreator.isValid());
-        		Tlsh sourceTlsh = sourceTlshCreator.getHash(false);
+			TlshCreator sourceTlshCreator = new TlshCreator(bucketOption, checksumOption);
+			sourceTlshCreator.update(sourceFile);
+			assertTrue("TLSH not valid for source file " + filesAndDiff.sourceFile + " (target file " + filesAndDiff.targetFile + ")",
+				sourceTlshCreator.isValid(smallSource));
+			Tlsh sourceTlsh = sourceTlshCreator.getHash(smallSource);
 
-        		TlshCreator targetTlshCreator = new TlshCreator(bucketOption, checksumOption);
-        		targetTlshCreator.update(targetFile);
-        		assertTrue(targetTlshCreator.isValid());
-        		Tlsh targetTlsh = targetTlshCreator.getHash(false);
+			TlshCreator targetTlshCreator = new TlshCreator(bucketOption, checksumOption);
+			targetTlshCreator.update(targetFile);
+			assertTrue("TLSH not valid for target file " + filesAndDiff.targetFile + " (source file " + filesAndDiff.sourceFile + ")",
+				targetTlshCreator.isValid(smallTarget));
+			Tlsh targetTlsh = targetTlshCreator.getHash(smallTarget);
 
-        		assertEquals("Incorrect diff for " + filesAndDiff.sourceFile + " and " + filesAndDiff.targetFile,
-        				filesAndDiff.expectedDiff, sourceTlsh.totalDiff(targetTlsh, includeLength));
-        		// Make sure diff is symmetric
-        		assertEquals("Incorrect diff for " + filesAndDiff.sourceFile + " and " + filesAndDiff.targetFile,
-        				filesAndDiff.expectedDiff, targetTlsh.totalDiff(sourceTlsh, includeLength));
-    		}
-    		
-    }
+			assertEquals("Incorrect diff for " + filesAndDiff.sourceFile + " and " + filesAndDiff.targetFile,
+					filesAndDiff.expectedDiff, sourceTlsh.totalDiff(targetTlsh, includeLength));
+			// Make sure diff is symmetric
+			assertEquals("Incorrect diff for " + filesAndDiff.sourceFile + " and " + filesAndDiff.targetFile,
+					filesAndDiff.expectedDiff, targetTlsh.totalDiff(sourceTlsh, includeLength));
+		}
+		
+	}
 
 	/** Test diff when checksums have different lengths */
-    @Test(expected=IllegalArgumentException.class)
-    public void test_diff_different_checksum() {
-    		byte[] buf = new byte[1024];
-    		new Random().nextBytes(buf);
-    		TlshCreator checksum1 = new TlshCreator(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B);
-    		checksum1.update(buf);
-    		Tlsh tlsh1 = checksum1.getHash();
+	@Test(expected=IllegalArgumentException.class)
+	public void test_diff_different_checksum() {
+		byte[] buf = new byte[1024];
+		new Random().nextBytes(buf);
+		TlshCreator checksum1 = new TlshCreator(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B);
+		checksum1.update(buf);
+		Tlsh tlsh1 = checksum1.getHash();
 
-    		TlshCreator checksum3 = new TlshCreator(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_3B);
-    		checksum3.update(buf);
-    		Tlsh tlsh3 = checksum3.getHash();
-    		
-    		tlsh1.totalDiff(tlsh3, true);
-    }
+		TlshCreator checksum3 = new TlshCreator(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_3B);
+		checksum3.update(buf);
+		Tlsh tlsh3 = checksum3.getHash();
+		
+		tlsh1.totalDiff(tlsh3, true);
+	}
 
 	/** Test diff with different bucket counts */
-    @Test(expected=IllegalArgumentException.class)
-    public void test_diff_different_buckets() {
-    		byte[] buf = new byte[1024];
-    		new Random().nextBytes(buf);
-    		TlshCreator buckets128 = new TlshCreator(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B);
-    		buckets128.update(buf);
-    		Tlsh tlsh128 = buckets128.getHash();
+	@Test(expected=IllegalArgumentException.class)
+	public void test_diff_different_buckets() {
+		byte[] buf = new byte[1024];
+		new Random().nextBytes(buf);
+		TlshCreator buckets128 = new TlshCreator(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B);
+		buckets128.update(buf);
+		Tlsh tlsh128 = buckets128.getHash();
 
-    		TlshCreator buckets256 = new TlshCreator(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_1B);
-    		buckets256.update(buf);
-    		Tlsh tlsh256 = buckets256.getHash();
-    		
-    		tlsh128.totalDiff(tlsh256, true);
-    }
+		TlshCreator buckets256 = new TlshCreator(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_1B);
+		buckets256.update(buf);
+		Tlsh tlsh256 = buckets256.getHash();
+		
+		tlsh128.totalDiff(tlsh256, true);
+	}
 
-    /**
-     * Test force flag in isValid call
-     */
-    @Test
-    public void test_isValid() {
-    		byte[] buf = new byte[TlshCreator.MIN_DATA_LENGTH];
-    		new Random().nextBytes(buf);
-    		TlshCreator tlshCreator = new TlshCreator();
-    		// not quite enough, even when forcing
-    		tlshCreator.update(buf, 0, TlshCreator.MIN_FORCE_DATA_LENGTH - 1);
+	/**
+	 * Test force flag in isValid call
+	 */
+	@Test
+	public void test_isValid() {
+		byte[] buf = new byte[TlshCreator.MIN_DATA_LENGTH];
+		new Random().nextBytes(buf);
+		TlshCreator tlshCreator = new TlshCreator();
+		// not quite enough, even when forcing
+		tlshCreator.update(buf, 0, TlshCreator.MIN_FORCE_DATA_LENGTH - 1);
 
-    		assertFalse(tlshCreator.isValid(false));
-    		assertFalse(tlshCreator.isValid(true));
+		assertFalse(tlshCreator.isValid(false));
+		assertFalse(tlshCreator.isValid(true));
 
-    		// one more byte should do it for forcing
-    		tlshCreator.update(buf, TlshCreator.MIN_FORCE_DATA_LENGTH - 1, 1);
+		// one more byte should do it for forcing
+		tlshCreator.update(buf, TlshCreator.MIN_FORCE_DATA_LENGTH - 1, 1);
 
-    		assertFalse(tlshCreator.isValid(false));
-    		assertTrue(tlshCreator.isValid(true));
+		assertFalse(tlshCreator.isValid(false));
+		assertTrue(tlshCreator.isValid(true));
 
-    		// add all but one of the remaining bytes, should not change validity
-    		tlshCreator.update(buf, TlshCreator.MIN_FORCE_DATA_LENGTH, (TlshCreator.MIN_DATA_LENGTH - TlshCreator.MIN_FORCE_DATA_LENGTH - 1));
-    		assertFalse(tlshCreator.isValid(false));
-    		assertTrue(tlshCreator.isValid(true));
+		// add all but one of the remaining bytes, should not change validity
+		tlshCreator.update(buf, TlshCreator.MIN_FORCE_DATA_LENGTH, (TlshCreator.MIN_DATA_LENGTH - TlshCreator.MIN_FORCE_DATA_LENGTH - 1));
+		assertFalse(tlshCreator.isValid(false));
+		assertTrue(tlshCreator.isValid(true));
 
-    		// add the last byte
-    		tlshCreator.update(buf, TlshCreator.MIN_DATA_LENGTH - 1, 1);
-    		assertTrue(tlshCreator.isValid(false));
-    		assertTrue(tlshCreator.isValid(true));
-    }
+		// add the last byte
+		tlshCreator.update(buf, TlshCreator.MIN_DATA_LENGTH - 1, 1);
+		assertTrue(tlshCreator.isValid(false));
+		assertTrue(tlshCreator.isValid(true));
+	}
 
-    /**
-     * Test input that is not varied enough
-     */
-    @Test
-    public void test_isValid_too_little_variance() {
-    		byte[] buf = new byte[1000];
-    		for (int i = 0; i < buf.length; ) {
-    			buf[i] = 'a';
-    			buf[i+1] = 'b';
-    			buf[i+2] = 'c';
-    			buf[i+3] = 'd';
-    			buf[i+4] = 'e';
-    			i+=5;
-    		}
+	/**
+	 * Test input that is not varied enough
+	 */
+	@Test
+	public void test_isValid_too_little_variance() {
+		byte[] buf = new byte[1000];
+		for (int i = 0; i < buf.length; ) {
+			buf[i] = 'a';
+			buf[i+1] = 'b';
+			buf[i+2] = 'c';
+			buf[i+3] = 'd';
+			buf[i+4] = 'e';
+			i+=5;
+		}
 
-    		TlshCreator tlshCreator = new TlshCreator();
-    		tlshCreator.update(buf);
+		TlshCreator tlshCreator = new TlshCreator();
+		tlshCreator.update(buf);
 
-    		// Should not be able to force validity
-    		assertFalse(tlshCreator.isValid(false));
-    		assertFalse(tlshCreator.isValid(true));
-    }
+		// Should not be able to force validity
+		assertFalse(tlshCreator.isValid(false));
+		assertFalse(tlshCreator.isValid(true));
+	}
 
-    /**
-     * Test force flag in getHash call
-     */
-    @Test
-    public void test_getHash() {
-    		byte[] buf = new byte[TlshCreator.MIN_DATA_LENGTH];
-    		new Random().nextBytes(buf);
-    		TlshCreator tlshCreator = new TlshCreator();
-    		// not quite enough, even when forcing
-    		tlshCreator.update(buf, 0, TlshCreator.MIN_FORCE_DATA_LENGTH - 1);
+	/**
+	 * Test force flag in getHash call
+	 */
+	@Test
+	public void test_getHash() {
+		byte[] buf = new byte[TlshCreator.MIN_DATA_LENGTH];
+		new Random().nextBytes(buf);
+		TlshCreator tlshCreator = new TlshCreator();
+		// not quite enough, even when forcing
+		tlshCreator.update(buf, 0, TlshCreator.MIN_FORCE_DATA_LENGTH - 1);
 
-    		try {
-    			tlshCreator.getHash();
-    			fail();
-    		} catch(IllegalStateException e) {
-    			// expected
-    		}
-    		try {
-    			tlshCreator.getHash(true);
-    			fail();
-    		} catch(IllegalStateException e) {
-    			// expected
-    		}
+		try {
+			tlshCreator.getHash();
+			fail();
+		} catch(IllegalStateException e) {
+			// expected
+		}
+		try {
+			tlshCreator.getHash(true);
+			fail();
+		} catch(IllegalStateException e) {
+			// expected
+		}
 
-    		// one more byte should do it for forcing
-    		tlshCreator.update(buf, TlshCreator.MIN_FORCE_DATA_LENGTH - 1, 1);
-    		assertNotNull(tlshCreator.getHash(true));
-    		try {
-    			tlshCreator.getHash();
-    			fail();
-    		} catch(IllegalStateException e) {
-    			// expected
-    		}
+		// one more byte should do it for forcing
+		tlshCreator.update(buf, TlshCreator.MIN_FORCE_DATA_LENGTH - 1, 1);
+		assertNotNull(tlshCreator.getHash(true));
+		try {
+			tlshCreator.getHash();
+			fail();
+		} catch(IllegalStateException e) {
+			// expected
+		}
 
-    		// add the last rest
-    		tlshCreator.update(buf, TlshCreator.MIN_FORCE_DATA_LENGTH, TlshCreator.MIN_DATA_LENGTH - TlshCreator.MIN_FORCE_DATA_LENGTH);
-    		assertNotNull(tlshCreator.getHash(true));
-    		assertNotNull(tlshCreator.getHash(false));
-    }
+		// add the last rest
+		tlshCreator.update(buf, TlshCreator.MIN_FORCE_DATA_LENGTH, TlshCreator.MIN_DATA_LENGTH - TlshCreator.MIN_FORCE_DATA_LENGTH);
+		assertNotNull(tlshCreator.getHash(true));
+		assertNotNull(tlshCreator.getHash(false));
+	}
 
-    /**
-     * Test input that is not varied enough
-     */
-    @Test
-    public void test_getHashNoThrow() {
-    		byte[] buf = new byte[TlshCreator.MIN_DATA_LENGTH];
-    		new Random().nextBytes(buf);
-    		TlshCreator tlshCreator = new TlshCreator();
-    		// not quite enough, even when forcing
-    		tlshCreator.update(buf, 0, TlshCreator.MIN_DATA_LENGTH - 1);
+	/**
+	 * Test input that is not varied enough
+	 */
+	@Test
+	public void test_getHashNoThrow() {
+		byte[] buf = new byte[TlshCreator.MIN_DATA_LENGTH];
+		new Random().nextBytes(buf);
+		TlshCreator tlshCreator = new TlshCreator();
+		// not quite enough, even when forcing
+		tlshCreator.update(buf, 0, TlshCreator.MIN_DATA_LENGTH - 1);
 
-    		assertNull(tlshCreator.getHashNoThrow());
+		assertNull(tlshCreator.getHashNoThrow());
 
-    		// add the final required byte
-    		tlshCreator.update(buf, TlshCreator.MIN_DATA_LENGTH - 1, 1);
-    		assertNotNull(tlshCreator.getHashNoThrow());
-    }
+		// add the final required byte
+		tlshCreator.update(buf, TlshCreator.MIN_DATA_LENGTH - 1, 1);
+		assertNotNull(tlshCreator.getHashNoThrow());
+	}
 
-    /**
-     * Test that multiple calls to the update(byte, int, int) method have the
-     * same result as one call to the update(byte) method
-     */
-    @Test
-    public void test_multiple_vs_single_updates() {
-    		byte[] buf = new byte[TlshCreator.MIN_DATA_LENGTH];
-    		new Random().nextBytes(buf);
+	/**
+	 * Test that multiple calls to the update(byte, int, int) method have the
+	 * same result as one call to the update(byte) method
+	 */
+	@Test
+	public void test_multiple_vs_single_updates() {
+		byte[] buf = new byte[TlshCreator.MIN_DATA_LENGTH];
+		new Random().nextBytes(buf);
 
-    		TlshCreator singleUpdate = new TlshCreator();
-    		singleUpdate.update(buf);
-    		Tlsh singleUpdateHash = singleUpdate.getHash();
+		TlshCreator singleUpdate = new TlshCreator();
+		singleUpdate.update(buf);
+		Tlsh singleUpdateHash = singleUpdate.getHash();
 
-    		TlshCreator multipleUpdates = new TlshCreator();
-    		for (int i = 0; i < buf.length; ++i) {
-    			multipleUpdates.update(buf, i, 1);
-    		}
-    		Tlsh multipleUpdatesHash = multipleUpdates.getHash();
-    		assertNotSame(singleUpdateHash, multipleUpdatesHash);
+		TlshCreator multipleUpdates = new TlshCreator();
+		for (int i = 0; i < buf.length; ++i) {
+			multipleUpdates.update(buf, i, 1);
+		}
+		Tlsh multipleUpdatesHash = multipleUpdates.getHash();
+		assertNotSame(singleUpdateHash, multipleUpdatesHash);
 
-    		assertEquals(singleUpdateHash.getEncoded(), multipleUpdatesHash.getEncoded());
+		assertEquals(singleUpdateHash.getEncoded(), multipleUpdatesHash.getEncoded());
 
-    }
+	}
 
-    @Test
-    public void test_from_encoded_string_128_1() {
-    		test_from_encoded_string(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B);
-    }
+	@Test
+	public void test_from_encoded_string_128_1() {
+		test_from_encoded_string(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_1B);
+	}
 
-    @Test
-    public void test_from_encoded_string_128_3() {
-    		test_from_encoded_string(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_3B);
-    }
+	@Test
+	public void test_from_encoded_string_128_3() {
+		test_from_encoded_string(BucketOption.BUCKETS_128, ChecksumOption.CHECKSUM_3B);
+	}
 
-    @Test
-    public void test_from_encoded_string_256_1() {
-    		test_from_encoded_string(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_1B);
-    }
+	@Test
+	public void test_from_encoded_string_256_1() {
+		test_from_encoded_string(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_1B);
+	}
 
-    @Test
-    public void test_from_encoded_string_256_3() {
-    		test_from_encoded_string(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_3B);
-    }
+	@Test
+	public void test_from_encoded_string_256_3() {
+		test_from_encoded_string(BucketOption.BUCKETS_256, ChecksumOption.CHECKSUM_3B);
+	}
 
-    /**
-     * Tests that encoded strings can be successfully decoded
-     */
-    private void test_from_encoded_string(BucketOption bucketOption, ChecksumOption checksumOption) {
-    		byte[] buf = new byte[TlshCreator.MIN_DATA_LENGTH];
-    		new Random().nextBytes(buf);
+	/**
+	 * Tests that encoded strings can be successfully decoded
+	 */
+	private void test_from_encoded_string(BucketOption bucketOption, ChecksumOption checksumOption) {
+		byte[] buf = new byte[TlshCreator.MIN_DATA_LENGTH];
+		new Random().nextBytes(buf);
 
-    		TlshCreator tlshCreator = new TlshCreator(bucketOption, checksumOption);
-    		tlshCreator.update(buf);
-    		Tlsh tlsh = tlshCreator.getHash();
-    		
-    		String encoded = tlsh.getEncoded();
-    		
-    		Tlsh decoded = Tlsh.fromTlshStr(encoded);
-    		
-    		assertEquals(0, tlsh.totalDiff(decoded, true));
-    		
-    		// make sure re-encoding is identical to original encoding
-    		String reEncoded = decoded.toString();
-    		
-    		assertEquals(encoded, reEncoded);
-    }
+		TlshCreator tlshCreator = new TlshCreator(bucketOption, checksumOption);
+		tlshCreator.update(buf);
+		Tlsh tlsh = tlshCreator.getHash();
+		
+		String encoded = tlsh.getEncoded();
+		
+		Tlsh decoded = Tlsh.fromTlshStr(encoded);
+		
+		assertEquals(0, tlsh.totalDiff(decoded, true));
+		
+		// make sure re-encoding is identical to original encoding
+		String reEncoded = decoded.toString();
+		
+		assertEquals(encoded, reEncoded);
+	}
 
-    /**
-     * Tests that lower-case strings can be successfully decoded
-     */
-    @Test
-    public void test_fromTlshStr_lowercase() {
-    		String encoded = "14d02b0987d87fa9f74228e362144b556ac8f02705130a5551476442a453e929c8842d";
+	/**
+	 * Tests that lower-case strings can be successfully decoded
+	 */
+	@Test
+	public void test_fromTlshStr_lowercase() {
+		String encoded = "14d02b0987d87fa9f74228e362144b556ac8f02705130a5551476442a453e929c8842d";
 
-    		Tlsh decoded = Tlsh.fromTlshStr(encoded);
-    		
-    		// make sure re-encoding is identical to original encoding
-    		String reEncoded = decoded.toString();
-    		
-    		assertEquals(encoded, reEncoded.toLowerCase());
-    }
+		Tlsh decoded = Tlsh.fromTlshStr(encoded);
+		
+		// make sure re-encoding is identical to original encoding
+		String reEncoded = decoded.toString();
+		
+		assertEquals(encoded, reEncoded.toLowerCase());
+	}
 
-    /**
-     * Test a string of wrong length is not decoded
-     */
-    @Test(expected=IllegalArgumentException.class)
-    public void test_fromTlshStr_bad_length() {
-    		String truncated = "14d02b0987d87fa9f74228e362144b556ac8f02705130a5551476442a453";
+	/**
+	 * Test a string of wrong length is not decoded
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void test_fromTlshStr_bad_length() {
+		String truncated = "14d02b0987d87fa9f74228e362144b556ac8f02705130a5551476442a453";
 
-    		Tlsh.fromTlshStr(truncated);
-    }
+		Tlsh.fromTlshStr(truncated);
+	}
 
-    /**
-     * Test a string of wrong length is not decoded
-     */
-    @Test(expected=IllegalArgumentException.class)
-    public void test_fromTlshStr_not_hex() {
-    		// right length, but last character not hex
-    		String notQuiteHex = "14D02B0987D87FA9F74228E362144B556AC8F02705130A5551476442A453E929C8842G";
+	/**
+	 * Test a string of wrong length is not decoded
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void test_fromTlshStr_not_hex() {
+		// right length, but last character not hex
+		String notQuiteHex = "14D02B0987D87FA9F74228E362144B556AC8F02705130A5551476442A453E929C8842G";
 
-    		Tlsh.fromTlshStr(notQuiteHex);
-    }
+		Tlsh.fromTlshStr(notQuiteHex);
+	}
 
-    
-    
+	/**
+	 * Lengthy test for input length above 2GB - Issue #84
+	 */
+	//@Test
+	public void test_large_input() {
+		byte[] b = new byte[1 << 10];
+		ThreadLocalRandom.current().nextBytes(b);
+		final long desiredInputSize = 0x9000_0000L;
+		long bytesHashed = 0;
+		TlshCreator creator = new TlshCreator();
+		while (bytesHashed < desiredInputSize) {
+			creator.update(b);
+			bytesHashed += b.length;
+		}
+		assertTrue(creator.isValid());
+		
+	}
+	
+	/**
+	 * Test bounds for l_capturing function
+	 */
+	@Test
+	public void test_l_capturing() {
+		assertEquals(169, TlshUtil.l_capturing(TlshCreator.MAX_DATA_LENGTH-1));
+		assertEquals(169, TlshUtil.l_capturing(TlshCreator.MAX_DATA_LENGTH));
+		try {
+			TlshUtil.l_capturing(TlshCreator.MAX_DATA_LENGTH+1);
+			fail("Expected exception for max length");
+		} catch (IllegalArgumentException e) {
+			// expected
+		}
+		
+	}
+	
 }


### PR DESCRIPTION
* Update TLSH Java implementation to understand new TLSH version data
* Partial fix for issue #84 to allow TLSH on files up to 4GiB
* Fix unit tests to work with new test data files
* Remove bintray hosting as it is being shut down