### PR TITLE
Fix the make install target by adding the `version.h` in the installed files

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -17,6 +17,10 @@ if [ $# -eq 1 -a "$1" = "debug" ]; then
   mkdir -p build/debug
   cd build/debug
   cmake -DCMAKE_BUILD_TYPE=Debug ../..
+elif [ $# -eq 1 -a "$1" = "-shared" ]; then
+  mkdir -p build/release
+  cd build/release
+  cmake -DTLSH_SHARED_LIBRARY=1 ../..
 else
   mkdir -p build/release
   cd build/release

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,10 @@ set_target_properties(tlsh PROPERTIES OUTPUT_NAME tlsh${BUILD_POSTFIX})
 # it was causing problems when compiling / testing tools on Linux
 ##########################
 
-set(TLSH_SHARED_LIBRARY 0)
+if (NOT DEFINED TLSH_SHARED_LIBRARY)
+    set(TLSH_SHARED_LIBRARY 0)
+endif()
+
 if(TLSH_SHARED_LIBRARY EQUAL 1)
     add_library(tlsh_shared SHARED ${TLSH_SRCS})
     set_target_properties(tlsh_shared PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/lib)
@@ -81,3 +84,4 @@ else()
 endif()
 
 install(FILES ../include/tlsh.h DESTINATION include)
+install(FILES ../include/version.h DESTINATION include)


### PR DESCRIPTION
Proposed fix for the issue #91 

If we do not want to remove the `make install` target for compatibility reason, we might as well own it and make it work properly.

I also added a way to build the shared lib version without having to modify cmake files as I feel the two modifications work in tandem

closes #91 