### PR TITLE
Build: Define default options only on "default"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,9 @@ set(VERSION_PATCH 2)
 
 # TLSH uses only half the counting buckets.
 # It can use all the buckets now.
+if(NOT TLSH_BUCKETS_48 AND NOT TLSH_BUCKETS_128 AND NOT TLSH_BUCKETS_256)
 set(TLSH_BUCKETS_128 1)
+endif()
 if(TLSH_BUCKETS_48 EQUAL 1)
   set(TLSH_HASH "min hash")
   add_definitions(-DBUCKETS_48)
@@ -77,7 +79,9 @@ endif()
 
 # TLSH uses 1 byte checksum. The collision rate is 1 in 24.
 # It can use 3 bytes checksum now. That collision rate in 1 in 5800.
+if(NOT TLSH_CHECKSUM_0B AND NOT TLSH_CHECKSUM_1B AND TLSH_CHECKSUM_3B)
 set(TLSH_CHECKSUM_1B 1)
+endif()
 
 if(TLSH_CHECKSUM_0B EQUAL 1)
   set(TLSH_CHECKSUM "no checksum")

--- a/include/tlsh.h
+++ b/include/tlsh.h
@@ -103,7 +103,7 @@ class TlshImpl;
 
 #if defined BUCKETS_48
   // No 3 Byte checksum option for 48 Bucket min hash
-  #define TLSH_STRING_LEN 30
+  #define TLSH_STRING_LEN_REQ 30
   // changed the minimum data length to 256 for version 3.3
   #define MIN_DATA_LENGTH		10
   // added the -force option for version 3.5


### PR DESCRIPTION
This commit sets default options only when no related options are specified.
With this, full hash (256 bucket variant) will compile just by `-DTLSH_BUCKETS_256=1`.

Just fixing CMakeLists.txt caused an error due to a failure to track with other changes on the version 4.0.0 on min hash (48 buckets variant) so this commit also fixes this issue.