### PR TITLE
py_ext: use PyVarObject_HEAD instead of PyObject_HEAD_INIT

### DIFF
--- a/py_ext/tlshmodule.cpp
+++ b/py_ext/tlshmodule.cpp
@@ -286,10 +286,7 @@ static PyGetSetDef Tlsh_getsetters[] = {
 };
 
 static PyTypeObject tlsh_TlshType = {
-    PyObject_HEAD_INIT(NULL)
-#if PY_MAJOR_VERSION < 3
-    0,                         /* ob_size */
-#endif
+    PyVarObject_HEAD_INIT(NULL, 0)
     "tlsh.Tlsh",               /* tp_name */
     sizeof(tlsh_TlshObject),   /* tp_basicsize */
     0,                         /* tp_itemsize */


### PR DESCRIPTION
This change allows building the Python extension for Python 3.12 with musl.

Patch first introduced in Gentoo: https://github.com/gentoo/gentoo/pull/36321