### PR TITLE
Remove call to sprintf() to avoid warnings

### DIFF
--- a/test/tlsh_unittest.cpp
+++ b/test/tlsh_unittest.cpp
@@ -152,8 +152,7 @@ int err;
 
 	char buf1[2000];
 	char buf2[2000];
-	char nullstr[6];
-	sprintf(nullstr, "TNULL");
+	char nullstr[] = "TNULL";
 
 	if (xref) {
 		if (output_json) {


### PR DESCRIPTION
@jonjoliver can you review it please?

Although `sprintf()` is considered insecure, in this case it's harmless as the string copied to `nullstr` is fixed. However, because this function is deprecated, the compiler emits a warning. This patch removes the function call as it's not really needed in this case.