### PR TITLE
Regard endianness independent of a specific CPU type or OS

### DIFF
--- a/include/tlsh_impl.h
+++ b/include/tlsh_impl.h
@@ -139,14 +139,12 @@ private:
         unsigned char checksum[TLSH_CHECKSUM_LEN];  // 1 to 3 bytes
         unsigned char Lvalue;                       // 1 byte
         union {
-#if defined(__SPARC) || defined(_AIX)
-		#pragma pack(1)
-#endif
-        unsigned char QB;
+        #pragma pack(1)
+            unsigned char QB;
             struct{
-#if defined(__SPARC) || defined(_AIX)
-		unsigned char Q2ratio : 4;
-		unsigned char Q1ratio : 4;
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+                unsigned char Q2ratio : 4;
+                unsigned char Q1ratio : 4;
 #else
                 unsigned char Q1ratio : 4;
                 unsigned char Q2ratio : 4;


### PR DESCRIPTION
Regard endianess based on __BYTE_ORDER__ instead of __SPARC or _AIX.

This makes sure endianness is handled correctly, at least with using GCC, without the need to fake a CPU type like proposed in https://github.com/trendmicro/tlsh/issues/131.

Picking endianness based on a specific OS seems not correct at all.