### PR TITLE
**4.13.1**

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ project(TLSH)
 
 set(VERSION_MAJOR 4)
 set(VERSION_MINOR 13)
-set(VERSION_PATCH 0)
+set(VERSION_PATCH 1)
 
 # TLSH uses only half the counting buckets.
 # It can use all the buckets now.

--- a/Change_History.md
+++ b/Change_History.md
@@ -754,3 +754,9 @@ TIME	ms= 21.00	per million iterations
 05/02/2026
 	Add CSV files to tlsh_pattern (preparation for a new py-tlsh release)
 </PRE>
+
+**4.13.1**
+<PRE>
+06/02/2026
+	Change default behaviour to output T1 at the start of the digest
+</PRE>

--- a/README.md
+++ b/README.md
@@ -296,10 +296,10 @@ TLSH similarity is expressed as a difference score:
 
 # Current Version
 
-**4.13.0**
+**4.13.1**
 <PRE>
-05/02/2026
-	Add CSV files to tlsh_pattern (preparation for a new py-tlsh release)
+06/02/2026
+	Change default behaviour to output T1 at the start of the digest
 </PRE>
 
 # Change History

--- a/include/tlsh.h
+++ b/include/tlsh.h
@@ -137,10 +137,10 @@ public:
     void final(const unsigned char* data = NULL, unsigned int len = 0, int fc_cons_option = 0);
 
     /* to get the hex-encoded hash code */
-    const char* getHash(int showvers=0) const ;
+    const char* getHash(int showvers=1) const ;
 
     /* to get the hex-encoded hash code without allocating buffer in TlshImpl - bufSize should be TLSH_STRING_BUFFER_LEN */
-    const char* getHash(char *buffer, unsigned int bufSize, int showvers=0) const;  
+    const char* getHash(char *buffer, unsigned int bufSize, int showvers=1) const;  
 
     /* to bring to object back to the initial state */
     void reset();

--- a/include/tlsh_win_version.h
+++ b/include/tlsh_win_version.h
@@ -7,7 +7,7 @@
 
 #define VERSION_MAJOR		4
 #define VERSION_MINOR		13
-#define VERSION_PATCH		0
+#define VERSION_PATCH		1
 #define TLSH_HASH		"compact hash"
 #define TLSH_CHECKSUM		"1 byte checksum"
 


### PR DESCRIPTION
06/02/2026
        Change default behaviour to output T1 at the start of the digest