### PR TITLE
**5.0.0**

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,9 @@ cmake_minimum_required(VERSION 2.6)
 
 project(TLSH)
 
-set(VERSION_MAJOR 4)
-set(VERSION_MINOR 13)
-set(VERSION_PATCH 4)
+set(VERSION_MAJOR 5)
+set(VERSION_MINOR 0)
+set(VERSION_PATCH 0)
 
 # TLSH uses only half the counting buckets.
 # It can use all the buckets now.

--- a/Change_History.md
+++ b/Change_History.md
@@ -778,3 +778,10 @@ TIME	ms= 21.00	per million iterations
 17/02/2026
 	Resolve #162 Reverse out T1 change made in 4.13.1
 </PRE>
+
+**5.0.0**
+<PRE>
+17/02/2026
+	Change default behaviour to output T1 at the start of the digest
+	A T1 digest requires that the number of buckets = 128 and the checksum is 1 byte
+</PRE>

--- a/README.md
+++ b/README.md
@@ -10,27 +10,21 @@ the detection of similar objects by comparing their hash values.  Note that
 the byte stream should have a sufficient amount of complexity.  For example,
 a byte stream of identical bytes will not generate a hash value.
 
-## What's (relatively) New in TLSH 4.12.x
-08/10/2024
+## What's New in TLSH 5.0.x
+17/02/2026
+The default behaviour is to input / output TLSH digests that start with the prefix "T1"
 
-Release version 4.10.x	- a Python clustering tool.
-- See the directory tlshCluster.
-
-I am going to try to make 4.12.0 a release version and build a py-tlsh Python library from 4.12.0
-4.12.0 includes:
-	Merge pull request #137 - this fixed a memory leak in py-tlsh
-	Merge pull request #134 - this improved the ifdef WINDOWS to be more portable
-4.12.1 includes:
-	Merge pull request #146 - Remove call to sprintf() to avoid warnings
-	Merge pull request #141 - py_ext: use PyVarObject_HEAD instead of PyObject_HEAD_INIT
-	Merge pull request #138 - Build: Define default options only on "default"
-	Merge pull request #136 - Bug Fix+Portability: Improve portability by integral division
+19/01/2026
+Released py-tlsh 4.12.1
 
 2020
 - adopted by [Virus Total](https://developers.virustotal.com/v3.0/reference#files-tlsh)
 - adopted by [Malware Bazaar](https://bazaar.abuse.ch/api/#tlsh)
 
 We have added a version identifier ("T1") to the start of the digest.
+The "T1" prefix is intended for the standard TLSH - that is
+- 128 buckets
+- the checksum is 1 byte
 Please use versions of TLSH that have the T1 header
 The code is backwards compatible, it can still read and interpret 70 hex character strings as TLSH digests.
 And data sets can include mixes of the old and new digests.
@@ -296,10 +290,11 @@ TLSH similarity is expressed as a difference score:
 
 # Current Version
 
-**4.13.4**
+**5.0.0**
 <PRE>
 17/02/2026
-	Resolve #162 Reverse out T1 change made in 4.13.1
+	Change default behaviour to output T1 at the start of the digest
+	A T1 digest requires that the number of buckets = 128 and the checksum is 1 byte
 </PRE>
 
 # Change History

--- a/include/tlsh.h
+++ b/include/tlsh.h
@@ -136,11 +136,15 @@ public:
     /* to signal the class there is no more data to be added */
     void final(const unsigned char* data = NULL, unsigned int len = 0, int fc_cons_option = 0);
 
+#if defined BUCKETS_128 && !defined(CHECKSUM_3B)
     /* to get the hex-encoded hash code */
-    const char* getHash(int showvers=0) const;
-
+    const char* getHash(int showvers=1) const;
     /* to get the hex-encoded hash code without allocating buffer in TlshImpl - bufSize should be TLSH_STRING_BUFFER_LEN */
+    const char* getHash(char *buffer, unsigned int bufSize, int showvers=1) const;
+#else
+    const char* getHash(int showvers=0) const;
     const char* getHash(char *buffer, unsigned int bufSize, int showvers=0) const;
+#endif
 
     /* to bring to object back to the initial state */
     void reset();

--- a/include/tlsh_win_version.h
+++ b/include/tlsh_win_version.h
@@ -5,9 +5,9 @@
  * Beware - do not change these values unless you really understand the software.
  ****************************************************/
 
-#define VERSION_MAJOR		4
-#define VERSION_MINOR		13
-#define VERSION_PATCH		4
+#define VERSION_MAJOR		5
+#define VERSION_MINOR		0
+#define VERSION_PATCH		0
 #define TLSH_HASH		"compact hash"
 #define TLSH_CHECKSUM		"1 byte checksum"
 

--- a/src/tlsh_impl.cpp
+++ b/src/tlsh_impl.cpp
@@ -794,6 +794,9 @@ int lsh_bin_fromTlshStr(struct lsh_bin_struct *this_lsh_bin, const char* str)
 	// Assume that we have 128 Buckets
 	int start = 0;
         if (strncmp(str, "T1", 2) == 0) {
+		// enforce that the T1 prefix is for TLSH digest with 128 buckets and 1 byte checksum
+		if ((EFF_BUCKETS != 128) || (TLSH_CHECKSUM_LEN != 1))
+			return 1;
 		start = 2;
 	} else {
 		start = 0;
@@ -805,7 +808,6 @@ int lsh_bin_fromTlshStr(struct lsh_bin_struct *this_lsh_bin, const char* str)
 			(str[i] >= 'A' && str[i] <= 'F') ||
 			(str[i] >= 'a' && str[i] <= 'f') ))
         	{
-			// printf("warning ii=%d str[%d]='%c'\n", ii, i, str[i]);
 			return 1;
 		}
 	}
@@ -814,7 +816,6 @@ int lsh_bin_fromTlshStr(struct lsh_bin_struct *this_lsh_bin, const char* str)
 		(str[xi] >= 'A' && str[xi] <= 'F') ||
 		(str[xi] >= 'a' && str[xi] <= 'f') ))
         {
-		// printf("warning xi=%d\n", xi);
 		return 1;
 	}
 	lsh_bin_struct tmp;

--- a/test/simple_unittest.cpp
+++ b/test/simple_unittest.cpp
@@ -72,7 +72,6 @@
 
 int main(int argc, char *argv[])
 {
-	int showvers = 1;
 	Tlsh t1;
 	Tlsh t2;
 
@@ -100,8 +99,8 @@ int main(int argc, char *argv[])
 	printf("str1 = '%s'\n", minSizeBuffer1 );
 	printf("str2 = '%s'\n", minSizeBuffer2 );
 
-	printf("hash1 = %s\n", t1.getHash(showvers) );
-	printf("hash2 = %s\n", t2.getHash(showvers) );
+	printf("hash1 = %s\n", t1.getHash() );
+	printf("hash2 = %s\n", t2.getHash() );
 
 	printf("difference (same strings) = %d\n", t1.totalDiff(&t1) );
 	printf("difference (with len) = %d\n", t1.totalDiff(&t2) );
@@ -117,7 +116,7 @@ int main(int argc, char *argv[])
 	minSizeBuffer1[511] = 0;
 	t3.update( (const unsigned char*) minSizeBuffer1+len1, 512-len1);
 	t3.final();
-	assert(strcmp(t1.getHash(showvers), t3.getHash(showvers)) == 0);
+	assert(strcmp(t1.getHash(), t3.getHash()) == 0);
 
     snprintf(minSizeBuffer2, sizeof(minSizeBuffer2), "%s", str2);
 	t4.update( (const unsigned char*) minSizeBuffer2, len2);
@@ -126,22 +125,22 @@ int main(int argc, char *argv[])
 	}
 	minSizeBuffer2[1023] = 0;
 	t4.final( (const unsigned char*) minSizeBuffer2+len2, 1024-len2);
-	assert(strcmp(t2.getHash(showvers), t4.getHash(showvers)) == 0);
+	assert(strcmp(t2.getHash(), t4.getHash()) == 0);
 
-	printf("hash3 = %s\n", t3.getHash(showvers) );
-	printf("hash4 = %s\n", t4.getHash(showvers) );
+	printf("hash3 = %s\n", t3.getHash() );
+	printf("hash4 = %s\n", t4.getHash() );
 
 	printf("Testing Tlsh.fromTlshStr()\n");
-	printf("Recreating tlsh3 from %s\n", t1.getHash(minSizeBuffer1, sizeof(minSizeBuffer1), showvers));
+	printf("Recreating tlsh3 from %s\n", t1.getHash(minSizeBuffer1, sizeof(minSizeBuffer1)));
 	t3.reset();
 	t3.fromTlshStr(minSizeBuffer1);
-	printf("hash3 = %s\n", t3.getHash(minSizeBuffer2, sizeof(minSizeBuffer2), showvers));
+	printf("hash3 = %s\n", t3.getHash(minSizeBuffer2, sizeof(minSizeBuffer2)));
 	assert(strcmp(minSizeBuffer1, minSizeBuffer2) == 0);
 	
-	printf("Recreating tlsh4 from %s\n", t2.getHash(minSizeBuffer1, sizeof(minSizeBuffer1), showvers));
+	printf("Recreating tlsh4 from %s\n", t2.getHash(minSizeBuffer1, sizeof(minSizeBuffer1)));
 	t4.reset();
 	t4.fromTlshStr(minSizeBuffer1);
-	printf("hash4 = %s\n", t4.getHash(minSizeBuffer2, sizeof(minSizeBuffer2), showvers));
+	printf("hash4 = %s\n", t4.getHash(minSizeBuffer2, sizeof(minSizeBuffer2)));
 	assert(strcmp(minSizeBuffer1, minSizeBuffer2) == 0);
 	printf("difference (same strings) = %d\n", t3.totalDiff(&t3) );
 	printf("difference (with len) = %d\n", t3.totalDiff(&t4) );


### PR DESCRIPTION
17/02/2026
        Change default behaviour to output T1 at the start of the digest
        A T1 digest requires that the number of buckets = 128 and the checksum is 1 byte