### PR TITLE
**5.0.1**

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ project(TLSH)
 
 set(VERSION_MAJOR 5)
 set(VERSION_MINOR 0)
-set(VERSION_PATCH 0)
+set(VERSION_PATCH 1)
 
 # TLSH uses only half the counting buckets.
 # It can use all the buckets now.

--- a/Change_History.md
+++ b/Change_History.md
@@ -785,3 +785,11 @@ TIME	ms= 21.00	per million iterations
 	Change default behaviour to output T1 at the start of the digest
 	A T1 digest requires that the number of buckets = 128 and the checksum is 1 byte
 </PRE>
+
+**5.0.1**
+<PRE>
+10/07/2026
+	PR #152 Increase cmake_minimum_required version for CMake 4 compat - thanks laumann
+	PR #155 Regard endianness independent of a specific CPU type or OS - thanks sge-d-o
+	PR #156 Make sure one of BUCKETS_* and one of CHECHKSUM_?B are always defined - thanks sge-d-o
+</PRE>

--- a/README.md
+++ b/README.md
@@ -290,11 +290,12 @@ TLSH similarity is expressed as a difference score:
 
 # Current Version
 
-**5.0.0**
+**5.0.1**
 <PRE>
-17/02/2026
-	Change default behaviour to output T1 at the start of the digest
-	A T1 digest requires that the number of buckets = 128 and the checksum is 1 byte
+10/07/2026
+	PR #152 Increase cmake_minimum_required version for CMake 4 compat - thanks laumann
+	PR #155 Regard endianness independent of a specific CPU type or OS - thanks sge-d-o
+	PR #156 Make sure one of BUCKETS_* and one of CHECHKSUM_?B are always defined - thanks sge-d-o
 </PRE>
 
 # Change History

--- a/include/tlsh_impl.h
+++ b/include/tlsh_impl.h
@@ -117,7 +117,7 @@ struct lsh_bin_struct
 	#endif
 	unsigned char QB;
 	    struct{
-	#if defined(__SPARC) || defined(_AIX)
+	#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 		unsigned char Q2ratio : 4;
 		unsigned char Q1ratio : 4;
 	#else

--- a/include/tlsh_win_version.h
+++ b/include/tlsh_win_version.h
@@ -7,7 +7,7 @@
 
 #define VERSION_MAJOR		5
 #define VERSION_MINOR		0
-#define VERSION_PATCH		0
+#define VERSION_PATCH		1
 #define TLSH_HASH		"compact hash"
 #define TLSH_CHECKSUM		"1 byte checksum"
 


### PR DESCRIPTION
10/07/2026
        PR #152 Increase cmake_minimum_required version for CMake 4 compat - thanks laumann
        PR #155 Regard endianness independent of a specific CPU type or OS - thanks sge-d-o
        PR #156 Make sure one of BUCKETS_* and one of CHECHKSUM_?B are always defined - thanks sge-d-o